### PR TITLE
Update wally.toml

### DIFF
--- a/wally.toml
+++ b/wally.toml
@@ -11,4 +11,4 @@ realm = "shared"
 # None :)
 
 [dev-dependencies]
-TestEZ = "roblox/testez@1.6.3"
+TestEZ = "roblox/testez@0.4.1"


### PR DESCRIPTION
TestEZ version seems to be incorrect; version listed [here](https://github.com/UpliftGames/wally-index/tree/main/roblox) is "roblox/testez@0.4.1"