### PR TITLE
Fix arguments being passed through `:Fire` leaking when a new thread is first created

### DIFF
--- a/default.project.json
+++ b/default.project.json
@@ -1,6 +1,14 @@
 {
 	"name": "goodsignal",
 	"tree": {
-		"$path": "src"
+		"$className": "DataModel",
+
+		"ReplicatedStorage": {
+			"$className": "ReplicatedStorage",
+
+			"GoodSignal": {
+				"$path": "src"
+			}
+		}
 	}
 }


### PR DESCRIPTION
Fixes [this issue.](https://devforum.roblox.com/t/lua-signal-class-comparison-optimal-goodsignal-class/1387063/40?u=lucasmz_rbx)

# Changes

* Makes it so that a thread never holds the arguments from when it was first created
* Fixed `default.project.json` file to automatically actually work with Rojo

# 

I think it’s worth it to change the behaviour for this on GoodSignal.

It only comes at a really, really small cost that is even more insignificant given it only costs more when creating a new thread, which again only happens when a handler errors or yields, which if you’re yielding then you don’t care about the performance cost anyhow.

This little aspect might cause confusion for users, even if it’s a rare edge case, they could be losing a lot of time trying to debug such a hidden issue.

Note: I have done some really basic test and it should be fine, but if you have a full-on tester of GoodSignal lying around I recommend running through it through that first. But you should be fine, these were really basic changes basically just adding and removing one line.