### PR TITLE
Add Signal:Once

### DIFF
--- a/src/init.lua
+++ b/src/init.lua
@@ -114,6 +114,15 @@ function Signal:Connect(fn)
 	return connection
 end
 
+function Signal:Once(fn)
+	local listener; listener = self:Connect(function(...)
+		-- Disconnect before calling the function to ensure the callback is only invoked once
+		listener:Disconnect()
+		fn(...)
+	end)
+	return listener
+end
+
 -- Disconnect all handlers. Since we use a linked list it suffices to clear the
 -- reference to the head handler.
 function Signal:DisconnectAll()


### PR DESCRIPTION
### Overview and reasoning
This pull request aims to put GoodSignal on par with what Roblox is bringing in a [future update](https://developer.roblox.com/en-us/resources/release-note/Release-Notes-for-531#Changes)
![image](https://user-images.githubusercontent.com/68239467/174096441-a4f1ee20-9315-4569-8f3f-901964d6aec5.png)


```lua
goodSignal:Once(function(...)
    -- Do stuff
end)
```

essentially this method is just syntax sugar for
```lua
local conn; conn = goodSignal:Connect(function(...)
    conn:Disconnect()
    -- Do stuff
end)
```

### Performance Comparison
![image](https://user-images.githubusercontent.com/68239467/174099010-06bbbfac-9d34-4083-b883-7de244aa6320.png)
(consider opening the results in fullscreen since it's hard to read in the preview 😞)
benchmarked using a Ryzen 9 3700X, your results may differ slightly
### What do these results mean?
The benchmark directly compares Signal:Once and what was called syntax sugar previously. Demonstrating that the difference is negligible in most use cases for the added functionality and readability. Unfortunately, at the time of making this Roblox's implementation hasn't been released publically. So there is no way to reasonably compare it against it.

### Changes are welcome
If you feel as if some part of the code can be changed to better suit the overall style of the module. Feel free to mention it in the comments or request an edit!

### Closing
having a method to connect a signal and instantly disconnect has been a pretty standard feature in a few signal libraries here's an example [SleitNicks implimentation](https://sleitnick.github.io/RbxUtil/api/Signal/#ConnectOnce) now that Roblox has decided to adopt the implementation it only seems fitting that GoodSignal should as well.