### PR TITLE
Fix leak of first set of arguments

### DIFF
--- a/wally.toml
+++ b/wally.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stravant/goodsignal"
 description = "A fast Signal class implementation that has full feature parity with Roblox' RBXScriptSignal"
-version = "0.2.0"
+version = "0.2.1"
 license = "MIT"
 authors = ["Mark Langen <stravant@gmail.com>"]
 registry = "https://github.com/UpliftGames/wally-index"


### PR DESCRIPTION
* Fix a subtle issue where if you never yield in the signal handler
  (such that the same runner thread is always being used), the first
  set of arguments passed to a Fire invocation will be leaked.

* The only way to avoid this is to not make use of the inital invocation
  of the runner thread, because there's no way to "clear" the "..." from
  the stack of runner thread without handcrafted LVM bytecode.

* This comes at a _slight_ performance penalty but only in very narrow
  case where you're using a lot of cheap but yielding event handlers.